### PR TITLE
Add content statistics utility for routing decisions

### DIFF
--- a/app/content_stats.py
+++ b/app/content_stats.py
@@ -1,0 +1,42 @@
+"""Content statistics utility for routing decisions.
+
+Computes lightweight text metrics (word count, line count, character count,
+average word length) that the semantic router can use to select appropriate
+models and cost tiers without invoking embeddings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ContentStats:
+    """Immutable container for content metrics."""
+
+    char_count: int
+    word_count: int
+    line_count: int
+    avg_word_length: float
+
+
+def compute_stats(text: str) -> ContentStats:
+    """Compute basic statistics for *text*.
+
+    Args:
+        text: Input text (may be empty).
+
+    Returns:
+        A :class:`ContentStats` instance with computed metrics.
+    """
+    char_count = len(text)
+    words = text.split()
+    word_count = len(words)
+    line_count = text.count("\n") + 1 if text else 0
+    avg_word_length = sum(len(w) for w in words) / word_count if word_count else 0.0
+    return ContentStats(
+        char_count=char_count,
+        word_count=word_count,
+        line_count=line_count,
+        avg_word_length=round(avg_word_length, 2),
+    )

--- a/tests/test_content_stats.py
+++ b/tests/test_content_stats.py
@@ -1,0 +1,63 @@
+"""Tests for the content statistics utility."""
+
+from app.content_stats import ContentStats, compute_stats
+
+
+class TestComputeStats:
+    """Unit tests for compute_stats()."""
+
+    def test_basic_sentence(self):
+        """Computes correct metrics for a simple sentence."""
+        stats = compute_stats("hello world")
+        assert stats.char_count == 11
+        assert stats.word_count == 2
+        assert stats.line_count == 1
+        assert stats.avg_word_length == 5.0
+
+    def test_multiline(self):
+        """Line count reflects newlines."""
+        stats = compute_stats("line one\nline two\nline three")
+        assert stats.line_count == 3
+        assert stats.word_count == 6
+
+    def test_empty_string(self):
+        """Empty input returns zeroed stats."""
+        stats = compute_stats("")
+        assert stats.char_count == 0
+        assert stats.word_count == 0
+        assert stats.line_count == 0
+        assert stats.avg_word_length == 0.0
+
+    def test_single_word(self):
+        """Single word has avg_word_length equal to its length."""
+        stats = compute_stats("python")
+        assert stats.word_count == 1
+        assert stats.avg_word_length == 6.0
+
+    def test_whitespace_only(self):
+        """Whitespace-only input has zero words."""
+        stats = compute_stats("   \n  \t  ")
+        assert stats.word_count == 0
+        assert stats.avg_word_length == 0.0
+        assert stats.char_count == 9
+
+    def test_avg_word_length_rounding(self):
+        """Average word length is rounded to 2 decimal places."""
+        stats = compute_stats("hi hey hello")
+        # lengths: 2, 3, 5 -> avg = 10/3 = 3.33
+        assert stats.avg_word_length == 3.33
+
+    def test_frozen_dataclass(self):
+        """ContentStats is immutable."""
+        stats = compute_stats("test")
+        try:
+            stats.char_count = 999
+            raised = False
+        except AttributeError:
+            raised = True
+        assert raised
+
+    def test_return_type(self):
+        """compute_stats returns a ContentStats instance."""
+        stats = compute_stats("hello")
+        assert isinstance(stats, ContentStats)


### PR DESCRIPTION
## Summary

Closes #15

Adds `app/content_stats.py` with a `compute_stats()` function returning a frozen `ContentStats` dataclass. Provides lightweight text metrics (word count, line count, char count, avg word length) for routing decisions without embedding calls.

## Changes

- **`app/content_stats.py`** — `ContentStats` frozen dataclass + `compute_stats()` pure function
- **`tests/test_content_stats.py`** — 8 unit tests: basic metrics, multiline, empty/whitespace, rounding, immutability

## Test plan

- [ ] `pytest tests/test_content_stats.py -v` passes all 8 tests
- [ ] `black --check app/content_stats.py tests/test_content_stats.py` passes
- [ ] `ruff check app/content_stats.py tests/test_content_stats.py` passes