### PR TITLE
fix: Account for special characters in token estimation

### DIFF
--- a/app/token_counter.py
+++ b/app/token_counter.py
@@ -12,6 +12,7 @@ more capable models with larger context windows.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 #: Average tokens per word for English text (empirically ~1.3 for GPT models).
@@ -21,6 +22,10 @@ TOKENS_PER_WORD: float = 1.3
 TIER_SHORT: int = 100
 TIER_MEDIUM: int = 500
 TIER_LONG: int = 2000
+
+#: Pattern matching non-alphanumeric, non-whitespace characters.
+#: Each of these typically becomes its own token in BPE tokenizers.
+_SPECIAL_CHAR_RE = re.compile(r"[^\w\s]")
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,12 +49,25 @@ def _classify_tier(estimated: int) -> str:
     return "very_long"
 
 
+def _count_special_chars(text: str) -> int:
+    """Count non-alphanumeric, non-whitespace characters.
+
+    LLM tokenizers (BPE) treat most punctuation and special characters
+    as individual tokens.  The word-based heuristic misses these because
+    ``str.split()`` groups them with adjacent words.
+    """
+    return len(_SPECIAL_CHAR_RE.findall(text))
+
+
 def estimate_tokens(text: str) -> TokenEstimate:
     """Estimate the token count for a text string.
 
-    Uses a word-based heuristic rather than a full tokenizer to avoid
-    adding heavy dependencies.  The estimate is intentionally conservative
-    (rounds up) to prevent under-budgeting.
+    Uses a word-based heuristic combined with a special-character
+    adjustment.  Each non-alphanumeric, non-whitespace character adds
+    approximately one extra token (BPE tokenizers split on punctuation).
+
+    The estimate is intentionally conservative (rounds up) to prevent
+    under-budgeting.
 
     Cost tiers:
     - ``"short"``: < 100 estimated tokens
@@ -65,7 +83,8 @@ def estimate_tokens(text: str) -> TokenEstimate:
     """
     words = text.split()
     word_count = len(words)
-    estimated = int(word_count * TOKENS_PER_WORD + 0.5)  # round up
+    special_chars = _count_special_chars(text)
+    estimated = int(word_count * TOKENS_PER_WORD + special_chars * 0.5 + 0.5)
 
     return TokenEstimate(
         text_length=len(text),

--- a/tests/test_token_counter_special.py
+++ b/tests/test_token_counter_special.py
@@ -1,0 +1,62 @@
+"""Tests for special-character-aware token estimation.
+
+Verifies that the token counter correctly accounts for punctuation, URLs,
+and code snippets that inflate actual token counts beyond the naive
+word-based heuristic.
+"""
+
+from app.token_counter import estimate_tokens, _count_special_chars
+
+
+class TestSpecialCharCounting:
+    """Verify special character detection."""
+
+    def test_plain_text_no_special(self):
+        assert _count_special_chars("hello world") == 0
+
+    def test_punctuation_counted(self):
+        assert _count_special_chars("hello, world!") == 2
+
+    def test_url_special_chars(self):
+        url = "https://example.com/path?q=1&lang=en"
+        # :, /, /, ., /, ?, =, &, =
+        count = _count_special_chars(url)
+        assert count >= 8
+
+    def test_code_snippet(self):
+        code = "def foo(x): return x['bar']"
+        count = _count_special_chars(code)
+        assert count >= 6  # (, ), :, [, ', ', ]
+
+
+class TestTokenEstimationWithSpecialChars:
+    """Verify token estimates account for special characters."""
+
+    def test_url_tokens_higher_than_word_count(self):
+        """A URL is 1 word but should estimate many more tokens."""
+        result = estimate_tokens("https://example.com/path?query=value&other=1")
+        assert result.word_count == 1
+        assert result.estimated_tokens > 3  # way more than 1 word * 1.3
+
+    def test_code_tokens_higher_than_word_count(self):
+        """Code with brackets and operators needs more tokens."""
+        code = "if (x > 0) { return arr[i]; }"
+        result = estimate_tokens(code)
+        assert result.estimated_tokens > result.word_count
+
+    def test_plain_text_minimally_affected(self):
+        """Plain English text should see minimal change."""
+        result = estimate_tokens("The quick brown fox jumps over the lazy dog")
+        # 9 words * 1.3 = 11.7 -> 12 tokens (no special chars)
+        assert result.estimated_tokens == 12
+
+    def test_empty_string(self):
+        result = estimate_tokens("")
+        assert result.estimated_tokens == 0
+        assert result.cost_tier == "short"
+
+    def test_json_payload(self):
+        """JSON payloads have many special chars."""
+        json_text = '{"name": "test", "values": [1, 2, 3]}'
+        result = estimate_tokens(json_text)
+        assert result.estimated_tokens > 5


### PR DESCRIPTION
## Summary

The word-based token estimator under-counts for inputs with URLs, code, or punctuation. LLM tokenizers (BPE) treat each special character as a separate token, so `https://example.com/path?q=1` produces ~15 tokens but only 1 "word".

- Add `_count_special_chars()` to detect non-alphanumeric characters
- Adjust the estimate by adding 0.5 tokens per special character
- Add tests for URLs, code snippets, JSON, and edge cases

Closes #23

## Test plan

- [ ] `pytest tests/test_token_counter_special.py -v` passes
- [ ] `pytest` full suite passes
- [ ] No regressions in existing token counter tests